### PR TITLE
Fix tree-sitter version conflict build error by tree-sitter-rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,13 +24,13 @@ serde = { version = "^1.0", features = ["derive"] }
 termcolor = "^1.2"
 walkdir = "^2.3"
 
-tree-sitter = "=0.20.9"
+tree-sitter = "=0.20.10"
 tree-sitter-java = "=0.20.0"
 tree-sitter-kotlin = "0.2.11"
 tree-sitter-typescript = "=0.20.1"
 tree-sitter-javascript = "=0.20.0"
 tree-sitter-python = "=0.20.2"
-tree-sitter-rust = "=0.20.3"
+tree-sitter-rust = "=0.20.4"
 tree-sitter-preproc = { path = "./tree-sitter-preproc", version = "=0.20.1" }
 tree-sitter-ccomment = { path = "./tree-sitter-ccomment", version = "=0.20.1" }
 tree-sitter-mozcpp = { path = "./tree-sitter-mozcpp", version = "=0.20.2" }

--- a/enums/Cargo.toml
+++ b/enums/Cargo.toml
@@ -8,13 +8,13 @@ edition = "2021"
 clap = { version = "^4.0", features = ["derive"] }
 askama = "^0.12"
 
-tree-sitter = "0.20.9"
+tree-sitter = "=0.20.10"
 tree-sitter-java = "=0.20.0"
 tree-sitter-kotlin = "0.2.11"
 tree-sitter-typescript = "=0.20.1"
 tree-sitter-javascript = "=0.20.0"
 tree-sitter-python = "=0.20.2"
-tree-sitter-rust = "=0.20.3"
+tree-sitter-rust = "=0.20.4"
 tree-sitter-preproc = { path = "../tree-sitter-preproc", version = "=0.20.1" }
 tree-sitter-ccomment = { path = "../tree-sitter-ccomment", version = "=0.20.1" }
 tree-sitter-mozcpp = { path = "../tree-sitter-mozcpp", version = "=0.20.2" }

--- a/tree-sitter-ccomment/Cargo.toml
+++ b/tree-sitter-ccomment/Cargo.toml
@@ -21,7 +21,7 @@ include = [
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = "0.20.9"
+tree-sitter = "=0.20.10"
 
 [build-dependencies]
 cc = "^1.0"

--- a/tree-sitter-mozcpp/Cargo.toml
+++ b/tree-sitter-mozcpp/Cargo.toml
@@ -21,7 +21,7 @@ include = [
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = "=0.20.9"
+tree-sitter = "=0.20.10"
 
 [build-dependencies]
 cc = "^1.0"

--- a/tree-sitter-mozjs/Cargo.toml
+++ b/tree-sitter-mozjs/Cargo.toml
@@ -21,7 +21,7 @@ include = [
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = "0.20.9"
+tree-sitter = "=0.20.10"
 
 [build-dependencies]
 cc = "^1.0"

--- a/tree-sitter-preproc/Cargo.toml
+++ b/tree-sitter-preproc/Cargo.toml
@@ -21,7 +21,7 @@ include = [
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = "0.20.9"
+tree-sitter = "=0.20.10"
 
 [build-dependencies]
 cc = "^1.0"


### PR DESCRIPTION
Currently, builds on the master branch fail with a tree-sitter dependency conflict issue. To resolve this, it needs to reset the depedencies with tree-sitter-rust, which is the culprit.